### PR TITLE
Make rounding to be 'half even'

### DIFF
--- a/pkg/money/money.go
+++ b/pkg/money/money.go
@@ -2,6 +2,7 @@ package money
 
 import (
 	"fmt"
+	"github.com/AltScore/money/pkg/utils"
 	"math"
 
 	"github.com/AltScore/money/pkg/parsers"
@@ -148,8 +149,8 @@ func (a Money) Div(divider int64) Money {
 func (a Money) RoundedDiv(divider int64) Money {
 	ma := a.asMoney()
 
-	mul := ma.Amount()*2/divider + 1
-	return fromEquivalentInt(mul/2, a.CurrencyCode())
+	div := utils.HalfEvenRounding(ma.Amount(), divider)
+	return fromEquivalentInt(div, a.CurrencyCode())
 }
 
 func (a Money) CurrencyCode() string {

--- a/pkg/money/money_test.go
+++ b/pkg/money/money_test.go
@@ -398,10 +398,65 @@ func TestMoney_RoundDiv_half_even_rounding_mode(t *testing.T) {
 			divider: 10,
 			want:    MustParse("0.10", "MXN"),
 		},
+
+		{
+			name:    "-0.15",
+			a:       MustParse("-0.15", "MXN"),
+			divider: 10,
+			want:    MustParse("-0.02", "MXN"),
+		},
+		{
+			name:    "-0.25",
+			a:       MustParse("-0.25", "MXN"),
+			divider: 10,
+			want:    MustParse("-0.02", "MXN"),
+		},
+		{
+			name:    "-0.35",
+			a:       MustParse("-0.35", "MXN"),
+			divider: 10,
+			want:    MustParse("-0.04", "MXN"),
+		},
+		{
+			name:    "-0.45",
+			a:       MustParse("-0.45", "MXN"),
+			divider: 10,
+			want:    MustParse("-0.04", "MXN"),
+		},
+		{
+			name:    "-0.55",
+			a:       MustParse("-0.55", "MXN"),
+			divider: 10,
+			want:    MustParse("-0.06", "MXN"),
+		},
+		{
+			name:    "-0.65",
+			a:       MustParse("-0.65", "MXN"),
+			divider: 10,
+			want:    MustParse("-0.06", "MXN"),
+		},
+		{
+			name:    "-.075",
+			a:       MustParse("-0.75", "MXN"),
+			divider: 10,
+			want:    MustParse("-0.08", "MXN"),
+		},
+		{
+			name:    "-0.85",
+			a:       MustParse("-0.85", "MXN"),
+			divider: 10,
+			want:    MustParse("-0.08", "MXN"),
+		},
+		{
+			name:    "-0.95",
+			a:       MustParse("-0.95", "MXN"),
+			divider: 10,
+			want:    MustParse("-0.10", "MXN"),
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equalf(t, tt.want, tt.a.RoundedDiv(tt.divider), "RoundedDiv(%v)", tt.divider)
+			assert.Equalf(t, tt.want, tt.a.RoundedDiv(tt.divider), "%v.RoundedDiv(%v)", tt.a, tt.divider)
 		})
 	}
 }

--- a/pkg/money/money_test.go
+++ b/pkg/money/money_test.go
@@ -288,28 +288,115 @@ func TestMoney_RoundDiv(t *testing.T) {
 			want:    MustParse("50.00", "MXN"),
 		},
 		{
-			name:    "Rounded 1",
+			name:    "Rounded 0.01",
 			a:       MustParse("0.01", "MXN"),
 			divider: 2,
-			want:    MustParse("0.01", "MXN"),
+			want:    MustParse("0.00", "MXN"), // because Half Even Rounding
 		},
 		{
-			name:    "Rounded 5",
+			name:    "Rounded 0.05",
 			a:       MustParse("0.05", "MXN"),
 			divider: 2,
-			want:    MustParse("0.03", "MXN"),
+			want:    MustParse("0.02", "MXN"), // because Half Even Rounding
 		},
 		{
-			name:    "Rounded 5",
+			name:    "Rounded 0.50 by 20",
 			a:       MustParse("0.50", "MXN"),
 			divider: 20,
-			want:    MustParse("0.03", "MXN"),
+			want:    MustParse("0.02", "MXN"), // because Half Even Rounding
 		},
 		{
-			name:    "Rounded 5",
+			name:    "Rounded 0.51 by 20",
+			a:       MustParse("0.51", "MXN"),
+			divider: 20,
+			want:    MustParse("0.03", "MXN"), // because Half Even Rounding
+		},
+		{
+			name:    "Rounded 0.49 by 20",
 			a:       MustParse("0.49", "MXN"),
 			divider: 20,
 			want:    MustParse("0.02", "MXN"),
+		},
+		{
+			name:    "Rounded 0.22 by 4",
+			a:       MustParse("0.22", "MXN"),
+			divider: 6,
+			want:    MustParse("0.04", "MXN"), // because Half Even Rounding
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, tt.a.RoundedDiv(tt.divider), "RoundedDiv(%v)", tt.divider)
+		})
+	}
+}
+
+func TestMoney_RoundDiv_half_even_rounding_mode(t *testing.T) {
+	tests := []struct {
+		name    string
+		a       Money
+		divider int64
+		want    Money
+	}{
+		{
+			name:    "Zero",
+			a:       MustParse("0.05", "MXN"),
+			divider: 10,
+			want:    MustParse("0.00", "MXN"),
+		},
+		{
+			name:    "0.15",
+			a:       MustParse("0.15", "MXN"),
+			divider: 10,
+			want:    MustParse("0.02", "MXN"),
+		},
+		{
+			name:    "0.25",
+			a:       MustParse("0.25", "MXN"),
+			divider: 10,
+			want:    MustParse("0.02", "MXN"),
+		},
+		{
+			name:    "0.35",
+			a:       MustParse("0.35", "MXN"),
+			divider: 10,
+			want:    MustParse("0.04", "MXN"),
+		},
+		{
+			name:    "0.45",
+			a:       MustParse("0.45", "MXN"),
+			divider: 10,
+			want:    MustParse("0.04", "MXN"),
+		},
+		{
+			name:    "0.55",
+			a:       MustParse("0.55", "MXN"),
+			divider: 10,
+			want:    MustParse("0.06", "MXN"),
+		},
+		{
+			name:    "0.65",
+			a:       MustParse("0.65", "MXN"),
+			divider: 10,
+			want:    MustParse("0.06", "MXN"),
+		},
+		{
+			name:    ".075",
+			a:       MustParse("0.75", "MXN"),
+			divider: 10,
+			want:    MustParse("0.08", "MXN"),
+		},
+		{
+			name:    "0.85",
+			a:       MustParse("0.85", "MXN"),
+			divider: 10,
+			want:    MustParse("0.08", "MXN"),
+		},
+		{
+			name:    "0.95",
+			a:       MustParse("0.95", "MXN"),
+			divider: 10,
+			want:    MustParse("0.10", "MXN"),
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/money/test_utils.go
+++ b/pkg/money/test_utils.go
@@ -1,6 +1,8 @@
 package money
 
-import "github.com/stretchr/testify/assert"
+import (
+	"github.com/stretchr/testify/assert"
+)
 
 func EqualAmount(t assert.TestingT, expected Money, actual Money) {
 	assert.Equal(t, expected.CurrencyCode(), actual.CurrencyCode())

--- a/pkg/utils/roundings.go
+++ b/pkg/utils/roundings.go
@@ -1,0 +1,28 @@
+package utils
+
+func HalfEvenRounding(a, b int64) int64 {
+	r := a * 2 / b // make division keeping first bit of remaining
+
+	switch r & 0b11 {
+	case 0b11:
+		// odd number, with excess
+		return r/2 + 1
+
+	case 0b10:
+		// odd number, without excess
+		return r / 2
+
+	case 0b01:
+		// even number, with excess
+		if r*b == a*2 {
+			return r / 2
+		}
+
+		return r/2 + 1
+
+	default:
+		// 0b00
+		// even number, without excess
+		return r / 2
+	}
+}

--- a/pkg/utils/roundings.go
+++ b/pkg/utils/roundings.go
@@ -1,6 +1,10 @@
 package utils
 
 func HalfEvenRounding(a, b int64) int64 {
+	if a > 0 && b < 0 || a < 0 && b > 0 {
+		return -HalfEvenRounding(-a, b)
+	}
+
 	r := a * 2 / b // make division keeping first bit of remaining
 
 	switch r & 0b11 {

--- a/pkg/utils/roundings_test.go
+++ b/pkg/utils/roundings_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func Test_check(t *testing.T) {
+	t.Skip("Used to see the behaviour of the rounding function")
 	b := int64(10)
 	for i := 0; i < 100; i++ {
 		a := int64(i)

--- a/pkg/utils/roundings_test.go
+++ b/pkg/utils/roundings_test.go
@@ -1,0 +1,129 @@
+package utils
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"strconv"
+	"testing"
+)
+
+func Test_check(t *testing.T) {
+	b := int64(10)
+	for i := 0; i < 100; i++ {
+		a := int64(i)
+		if a%10 == 0 {
+			fmt.Println()
+		}
+
+		f := float64(a) / float64(b)
+		r := a * 2 / b
+
+		fmt.Printf("%3d %10.3f [%5s] %3d -> %3d\n", a, f, strconv.FormatInt(r, 2), r*b/2, HalfEvenRounding(a, b))
+	}
+}
+
+func Test_halfEvenRounding(t *testing.T) {
+	type args struct {
+		a int64
+		b int64
+	}
+	tests := []struct {
+		name string
+		args args
+		want int64
+	}{
+		{
+			name: "0.4",
+			args: args{a: 4, b: 10},
+			want: 0,
+		},
+		{
+			name: "0.5",
+			args: args{a: 5, b: 10},
+			want: 0,
+		},
+		{
+			name: "0.6",
+			args: args{a: 6, b: 10},
+			want: 1,
+		},
+		{
+			name: "1.4",
+			args: args{a: 14, b: 10},
+			want: 1,
+		},
+		{
+			name: "1.5",
+			args: args{a: 15, b: 10},
+			want: 2,
+		},
+		{
+			name: "1.6",
+			args: args{a: 15, b: 10},
+			want: 2,
+		},
+		{
+			name: "2.4",
+			args: args{a: 24, b: 10},
+			want: 2,
+		}, {
+			name: "2.5",
+			args: args{a: 25, b: 10},
+			want: 2,
+		}, {
+			name: "2.6",
+			args: args{a: 26, b: 10},
+			want: 3,
+		},
+		{
+			name: "3.4",
+			args: args{a: 34, b: 10},
+			want: 3,
+		},
+		{
+			name: "3.5",
+			args: args{a: 35, b: 10},
+			want: 4,
+		},
+		{
+			name: "3.6",
+			args: args{a: 36, b: 10},
+			want: 4,
+		},
+		{
+			name: "4.5",
+			args: args{a: 45, b: 10},
+			want: 4,
+		},
+		{
+			name: "5.5",
+			args: args{a: 55, b: 10},
+			want: 6,
+		},
+		{
+			name: "6.5",
+			args: args{a: 65, b: 10},
+			want: 6,
+		},
+		{
+			name: "7.5",
+			args: args{a: 75, b: 10},
+			want: 8,
+		},
+		{
+			name: "8.5",
+			args: args{a: 85, b: 10},
+			want: 8,
+		},
+		{
+			name: "9.5",
+			args: args{a: 95, b: 10},
+			want: 10,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, HalfEvenRounding(tt.args.a, tt.args.b), "halfEvenRounding(%v, %v)", tt.args.a, tt.args.b)
+		})
+	}
+}

--- a/pkg/utils/roundings_test.go
+++ b/pkg/utils/roundings_test.go
@@ -120,6 +120,95 @@ func Test_halfEvenRounding(t *testing.T) {
 			args: args{a: 95, b: 10},
 			want: 10,
 		},
+
+		{
+			name: "-0.4",
+			args: args{a: -4, b: 10},
+			want: 0,
+		},
+		{
+			name: "-0.5",
+			args: args{a: -5, b: 10},
+			want: 0,
+		},
+		{
+			name: "-0.6",
+			args: args{a: -6, b: 10},
+			want: -1,
+		},
+		{
+			name: "-1.4",
+			args: args{a: -14, b: 10},
+			want: -1,
+		},
+		{
+			name: "-1.5",
+			args: args{a: -15, b: 10},
+			want: -2,
+		},
+		{
+			name: "-1.6",
+			args: args{a: -15, b: 10},
+			want: -2,
+		},
+		{
+			name: "-2.4",
+			args: args{a: -24, b: 10},
+			want: -2,
+		}, {
+			name: "-2.5",
+			args: args{a: -25, b: 10},
+			want: -2,
+		}, {
+			name: "-2.6",
+			args: args{a: -26, b: 10},
+			want: -3,
+		},
+		{
+			name: "-3.4",
+			args: args{a: -34, b: 10},
+			want: -3,
+		},
+		{
+			name: "-3.5",
+			args: args{a: -35, b: 10},
+			want: -4,
+		},
+		{
+			name: "-3.6",
+			args: args{a: -36, b: 10},
+			want: -4,
+		},
+		{
+			name: "-4.5",
+			args: args{a: -45, b: 10},
+			want: -4,
+		},
+		{
+			name: "-5.5",
+			args: args{a: -55, b: 10},
+			want: -6,
+		},
+		{
+			name: "-6.5",
+			args: args{a: -65, b: 10},
+			want: -6,
+		},
+		{
+			name: "-7.5",
+			args: args{a: -75, b: 10},
+			want: -8,
+		},
+		{
+			name: "-8.5",
+			args: args{a: -85, b: 10},
+			want: -8,
+		},
+		{
+			name: "-9.5",
+			args: args{a: -95, b: 10},
+			want: -10,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Se ajusta el redondeo para tener un modo de redondeo "half even".

En este modo la mitad de los redondeos que caen justo en el medio van hacia un lado y la otra mitad hacia el otro, compensando las diferencias en grandes números.

Este el modo por defecto de Fineract.